### PR TITLE
If you own an event and there are people who have joined your event, you

### DIFF
--- a/client/modules/Event/components/EventPageDetails/Host/Attendees/index.jsx
+++ b/client/modules/Event/components/EventPageDetails/Host/Attendees/index.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+/* eslint-disable react/prop-types */
+const Attendees = ({ attendees }) => (
+  <div>
+    These users are currently subscribed to your event!
+    {
+      attendees.map((user) => {
+        return (
+          <div>
+            {user}
+          </div>
+        );
+      })
+    }
+  </div>
+);
+
+export default Attendees;

--- a/client/modules/Event/components/EventPageDetails/Host/index.jsx
+++ b/client/modules/Event/components/EventPageDetails/Host/index.jsx
@@ -3,6 +3,7 @@ import EventDetails from '../EventDetails';
 import FormEditWrap from './FormEditWrap/';
 import { deleteEventRequest } from '../../../EventActions';
 import Delete from './Delete/';
+import Attendees from './Attendees';
 
 /* eslint-disable react/prop-types */
 
@@ -83,6 +84,7 @@ class HostDetails extends Component {
           deleteMode={this.state.deleteMode}
           deleteConfirm={this.deleteConfirm}
         />
+        <Attendees attendees={this.props.event.attendees} />
       </div>
     );
   }


### PR DESCRIPTION
may now see their ID's when you view the details of your event. This
will be easily updated once the models carry the full names of the
participants.