### PR TITLE
This commit separates the "general" event view from the hosts own view.

### DIFF
--- a/client/modules/Event/components/EventPageDetails/Host/HostDetails.js
+++ b/client/modules/Event/components/EventPageDetails/Host/HostDetails.js
@@ -68,7 +68,6 @@ class HostDetails extends Component {
               event={this.props.event}
               styles={this.props.styles}
             />
-            This is the owners page.
           </div>
         }
         {this.state.editing ? '' :

--- a/client/modules/Event/pages/UserEventPage/UserEventPage.js
+++ b/client/modules/Event/pages/UserEventPage/UserEventPage.js
@@ -23,7 +23,7 @@ import { getEvents } from '../../EventReducer';
 import { getAuthUser } from '../../../Auth/AuthReducer';
 import { getUserEvents } from '../../../Event/UserEventsReducer';
 
-class EventListPage extends Component {
+class UserEventPage extends Component {
   componentDidMount() {
     this.props.dispatch(fetchEvents());
     this.props.dispatch(fetchAuthUserEventsRequest());
@@ -49,8 +49,10 @@ class EventListPage extends Component {
         {_.isObject(this.props.authUser) &&
           <div>
             <EventCreateWidget addEvent={this.handleAddEvent} showAddEvent={this.props.showAddEvent} authUser={this.props.authUser} />
-            <h5>Events Around You</h5>
-            <EventList handleDeleteEvent={this.handleDeleteEvent} events={this.props.events} />
+            <div>
+              <h5>Your Events</h5>
+              <EventList handleDeleteEvent={this.handleDeleteEvent} events={this.props.userEvents} />
+            </div>
           </div>
         }
 
@@ -66,7 +68,7 @@ class EventListPage extends Component {
 }
 
 // Actions required to provide data for this component to render in sever side.
-EventListPage.need = [() => { return fetchEvents(); }];
+UserEventPage.need = [() => { return fetchEvents(); }];
 
 // Retrieve data from store as props
 function mapStateToProps(state, props) {
@@ -78,7 +80,7 @@ function mapStateToProps(state, props) {
   };
 }
 
-EventListPage.propTypes = {
+UserEventPage.propTypes = {
   events: PropTypes.arrayOf(PropTypes.shape({
     eventName: PropTypes.string.isRequired,
     game: PropTypes.string.isRequired,
@@ -93,8 +95,8 @@ EventListPage.propTypes = {
   userEvents: PropTypes.array,
 };
 
-EventListPage.contextTypes = {
+UserEventPage.contextTypes = {
   router: React.PropTypes.object,
 };
 
-export default connect(mapStateToProps)(EventListPage);
+export default connect(mapStateToProps)(UserEventPage);

--- a/client/routes.js
+++ b/client/routes.js
@@ -19,7 +19,7 @@ if (process.env.NODE_ENV !== 'production') {
   require('./modules/Post/pages/PostListPage/PostListPage');
   require('./modules/Post/pages/PostDetailPage/PostDetailPage');
   require('./modules/Event/pages/EventListPage/EventListPage');
-  require('./modules/Event/pages/EventDetailPage/EventDetailPage');
+  require('./modules/Event/pages/UserEventPage/UserEventPage');
 }
 
 // react-router setup with code-splitting
@@ -45,7 +45,7 @@ export default (
       path="/games/"
       getComponent={(nextState, cb) => {
         require.ensure([], require => {
-          cb(null, require('./modules/Event/pages/EventListPage/EventListPage').default);
+          cb(null, require('./modules/Event/pages/UserEventPage/UserEventPage').default);
         });
       }}
     />


### PR DESCRIPTION
Now when you connect to the index of the page, you'll see all the events
listed. When you click on "Show my events" or whichever button, you'll
see only the events you host.

TODO: I'd like to add a special icon on the main page for events you're
hosting. Perhaps just a little green something